### PR TITLE
User namespace isolation

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -29,6 +29,8 @@ class Settings:
     
     # Kubernetes Configuration
     CLUSTER_EXTERNAL_IP = os.getenv("CLUSTER_EXTERNAL_IP", None)  # IP externe du cluster K8s
+    # Préfixe des namespaces utilisateur (un namespace par utilisateur)
+    USER_NAMESPACE_PREFIX = os.getenv("USER_NAMESPACE_PREFIX", "labondemand-user")
     
     @staticmethod
     def init_kubernetes():

--- a/backend/k8s_router.py
+++ b/backend/k8s_router.py
@@ -7,11 +7,14 @@ from kubernetes import client
 from typing import List, Dict, Any, Optional
 
 from .security import get_current_user, is_admin, is_teacher_or_admin
-from .models import User, UserRole
+from .models import User, UserRole, Template
 from .k8s_utils import validate_k8s_name
 from .deployment_service import deployment_service
 from .templates import get_deployment_templates, get_resource_presets_for_role
 from .config import settings
+from sqlalchemy.orm import Session
+from .database import get_db
+from . import schemas
 
 router = APIRouter(prefix="/api/v1/k8s", tags=["kubernetes"])
 
@@ -363,9 +366,98 @@ async def delete_deployment(
 # ============= ENDPOINTS DE TEMPLATES ET PRESETS =============
 
 @router.get("/templates")
-async def get_deployment_templates_endpoint(current_user: User = Depends(get_current_user)):
-    """Récupérer les templates de déploiement"""
+async def get_deployment_templates_endpoint(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """Récupérer les templates de déploiement actifs (DB), fallback sur defaults"""
+    templates = db.query(Template).filter(Template.active == True).all()
+    if templates:
+        return {"templates": [
+            {
+                "id": t.key,
+                "name": t.name,
+                "description": t.description,
+                "icon": t.icon,
+                "default_image": t.default_image,
+                "default_port": t.default_port,
+                "deployment_type": t.deployment_type,
+                "default_service_type": t.default_service_type,
+            } for t in templates
+        ]}
+    # Fallback: templates codés
     return get_deployment_templates()
+
+
+@router.post("/templates", response_model=schemas.TemplateResponse)
+async def create_template(
+    payload: schemas.TemplateCreate,
+    current_user: User = Depends(get_current_user),
+    _: bool = Depends(is_admin),
+    db: Session = Depends(get_db)
+):
+    """Créer un template (admin)"""
+    # Vérifier unicité de la clé
+    if db.query(Template).filter(Template.key == payload.key).first():
+        raise HTTPException(status_code=400, detail="La clé du template existe déjà")
+    tpl = Template(
+        key=payload.key,
+        name=payload.name,
+        description=payload.description,
+        icon=payload.icon,
+        deployment_type=payload.deployment_type,
+        default_image=payload.default_image,
+        default_port=payload.default_port,
+        default_service_type=payload.default_service_type,
+        active=payload.active,
+    )
+    db.add(tpl)
+    db.commit()
+    db.refresh(tpl)
+    return tpl
+
+
+@router.get("/templates/all", response_model=List[schemas.TemplateResponse])
+async def list_all_templates(
+    current_user: User = Depends(get_current_user),
+    _: bool = Depends(is_admin),
+    db: Session = Depends(get_db)
+):
+    """Lister tous les templates (admin)"""
+    return db.query(Template).order_by(Template.id.desc()).all()
+
+
+@router.put("/templates/{template_id}", response_model=schemas.TemplateResponse)
+async def update_template(
+    template_id: int,
+    payload: schemas.TemplateUpdate,
+    current_user: User = Depends(get_current_user),
+    _: bool = Depends(is_admin),
+    db: Session = Depends(get_db)
+):
+    tpl = db.query(Template).filter(Template.id == template_id).first()
+    if not tpl:
+        raise HTTPException(status_code=404, detail="Template non trouvé")
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        setattr(tpl, field, value)
+    db.commit()
+    db.refresh(tpl)
+    return tpl
+
+
+@router.delete("/templates/{template_id}")
+async def delete_template(
+    template_id: int,
+    current_user: User = Depends(get_current_user),
+    _: bool = Depends(is_admin),
+    db: Session = Depends(get_db)
+):
+    tpl = db.query(Template).filter(Template.id == template_id).first()
+    if not tpl:
+        raise HTTPException(status_code=404, detail="Template non trouvé")
+    db.delete(tpl)
+    db.commit()
+    return {"message": "Template supprimé"}
 
 @router.get("/resource-presets")
 async def get_resource_presets(current_user: User = Depends(get_current_user)):

--- a/backend/models.py
+++ b/backend/models.py
@@ -33,3 +33,21 @@ class User(Base):
     is_active = Column(Boolean, default=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+
+# Modèle pour les templates d'application (déploiements)
+class Template(Base):
+    __tablename__ = "templates"
+
+    id = Column(Integer, primary_key=True, index=True)
+    key = Column(String(50), unique=True, index=True, nullable=False)  # identifiant fonctionnel (ex: vscode, jupyter)
+    name = Column(String(100), nullable=False)
+    description = Column(String(255), nullable=True)
+    icon = Column(String(100), nullable=True)  # ex: fa-solid fa-code
+    deployment_type = Column(String(30), nullable=False, default="custom")  # vscode|jupyter|custom
+    default_image = Column(String(200), nullable=True)
+    default_port = Column(Integer, nullable=True)
+    default_service_type = Column(String(30), nullable=False, default="NodePort")  # ClusterIP|NodePort|LoadBalancer
+    active = Column(Boolean, default=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -59,3 +59,40 @@ class SessionData(BaseModel):
 class LoginResponse(BaseModel):
     user: UserResponse
     session_id: str
+
+
+# ====== Templates ======
+class TemplateBase(BaseModel):
+    key: str = Field(..., min_length=2, max_length=50)
+    name: str = Field(..., min_length=2, max_length=100)
+    description: Optional[str] = Field(None, max_length=255)
+    icon: Optional[str] = Field(None, max_length=100)
+    deployment_type: str = Field("custom", pattern=r"^(custom|vscode|jupyter)$")
+    default_image: Optional[str] = Field(None, max_length=200)
+    default_port: Optional[int] = Field(None, ge=1, le=65535)
+    default_service_type: str = Field("NodePort", pattern=r"^(ClusterIP|NodePort|LoadBalancer)$")
+    active: bool = True
+
+
+class TemplateCreate(TemplateBase):
+    pass
+
+
+class TemplateUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=2, max_length=100)
+    description: Optional[str] = Field(None, max_length=255)
+    icon: Optional[str] = Field(None, max_length=100)
+    deployment_type: Optional[str] = Field(None, pattern=r"^(custom|vscode|jupyter)$")
+    default_image: Optional[str] = Field(None, max_length=200)
+    default_port: Optional[int] = Field(None, ge=1, le=65535)
+    default_service_type: Optional[str] = Field(None, pattern=r"^(ClusterIP|NodePort|LoadBalancer)$")
+    active: Optional[bool] = None
+
+
+class TemplateResponse(TemplateBase):
+    id: int
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+
+    class Config:
+        from_attributes = True

--- a/backend/templates.py
+++ b/backend/templates.py
@@ -15,7 +15,9 @@ def get_deployment_templates() -> Dict[str, List[Dict[str, Any]]]:
                 "id": "custom",
                 "name": "Déploiement personnalisé",
                 "description": "Déployer une image Docker de votre choix",
-                "icon": "fa-docker"
+                "icon": "fa-docker",
+                "deployment_type": "custom",
+                "default_service_type": "NodePort"
             },
             {
                 "id": "vscode",
@@ -23,7 +25,9 @@ def get_deployment_templates() -> Dict[str, List[Dict[str, Any]]]:
                 "description": "Déployer un environnement de développement VS Code accessible via navigateur",
                 "icon": "fa-code",
                 "default_image": "tutanka01/k8s:vscode",
-                "default_port": 8080
+                "default_port": 8080,
+                "deployment_type": "vscode",
+                "default_service_type": "NodePort"
             },
             {
                 "id": "jupyter",
@@ -31,7 +35,9 @@ def get_deployment_templates() -> Dict[str, List[Dict[str, Any]]]:
                 "description": "Déployer un environnement Jupyter Notebook pour l'analyse de données et le machine learning",
                 "icon": "fa-chart-line",
                 "default_image": "tutanka01/k8s:jupyter",
-                "default_port": 8888
+                "default_port": 8888,
+                "deployment_type": "jupyter",
+                "default_service_type": "NodePort"
             }
         ]
     }

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -37,7 +37,7 @@
             </div>
         </header>
 
-        <main>
+    <main>
             <div class="page-header">
                 <h1><i class="fas fa-users-cog"></i> Administration des utilisateurs</h1>
                 <button id="add-user-btn" class="action-btn">
@@ -101,6 +101,19 @@
                     Suivant <i class="fas fa-chevron-right"></i>
                 </button>
             </div>
+
+            <!-- Gestion des Templates d'applications -->
+            <section class="admin-section" id="templates-section">
+                <div class="page-header">
+                    <h2><i class="fas fa-th-large"></i> Templates d'application</h2>
+                    <button id="add-template-btn" class="action-btn">
+                        <i class="fas fa-plus"></i> Nouveau template
+                    </button>
+                </div>
+                <div id="templates-list" class="users-table-container">
+                    <!-- Rempli par JS -->
+                </div>
+            </section>
         </main>
     </div>
 
@@ -178,6 +191,85 @@
         </div>
     </div>
 
+    <!-- Modal Templates (création/édition) -->
+    <div id="template-modal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 id="template-modal-title"><i class="fas fa-th-large"></i> Nouveau template</h2>
+                <button class="close-template-modal"><i class="fas fa-times"></i></button>
+            </div>
+            <div class="modal-body">
+                <form id="template-form">
+                    <input type="hidden" id="template-id">
+
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="tpl-key"><i class="fas fa-key"></i> Clé</label>
+                            <input type="text" id="tpl-key" required minlength="2" maxlength="50" placeholder="vscode">
+                            <small>Identifiant unique (ex: vscode, jupyter, custom)</small>
+                        </div>
+                        <div class="form-group">
+                            <label for="tpl-name"><i class="fas fa-tag"></i> Nom</label>
+                            <input type="text" id="tpl-name" required minlength="2" maxlength="100" placeholder="VSCode Web">
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="tpl-description"><i class="fas fa-align-left"></i> Description</label>
+                        <input type="text" id="tpl-description" maxlength="255" placeholder="Courte description">
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="tpl-icon"><i class="fas fa-icons"></i> Icône (classe)</label>
+                            <input type="text" id="tpl-icon" maxlength="100" placeholder="fa-solid fa-code">
+                            <small>Classe Font Awesome (ex: fa-solid fa-code)</small>
+                        </div>
+                        <div class="form-group">
+                            <label for="tpl-type"><i class="fas fa-cubes"></i> Type</label>
+                            <select id="tpl-type">
+                                <option value="custom">Custom</option>
+                                <option value="vscode">VSCode</option>
+                                <option value="jupyter">Jupyter</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="tpl-image"><i class="fas fa-box"></i> Image par défaut</label>
+                            <input type="text" id="tpl-image" maxlength="200" placeholder="ex: tutanka01/k8s:vscode">
+                        </div>
+                        <div class="form-group">
+                            <label for="tpl-port"><i class="fas fa-plug"></i> Port par défaut</label>
+                            <input type="number" id="tpl-port" min="1" max="65535" placeholder="ex: 8080">
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="tpl-service-type"><i class="fas fa-network-wired"></i> Type de service</label>
+                        <select id="tpl-service-type">
+                            <option value="ClusterIP">ClusterIP</option>
+                            <option value="NodePort" selected>NodePort</option>
+                            <option value="LoadBalancer">LoadBalancer</option>
+                        </select>
+                    </div>
+
+                    <div class="form-group checkbox-group">
+                        <input type="checkbox" id="tpl-active" checked>
+                        <label for="tpl-active">Actif</label>
+                    </div>
+
+                    <div class="form-actions">
+                        <button type="button" class="btn-cancel close-template-modal">Annuler</button>
+                        <button type="submit" class="btn-save">Enregistrer</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
     <script src="js/admin.js"></script>
+    <script src="js/templates.js"></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -84,22 +84,8 @@
             <button class="btn btn-secondary back-btn" data-target="dashboard-view"><i class="fas fa-arrow-left"></i> Retour</button>
             <h1><i class="fas fa-th-large"></i> Choisir un Service</h1>
             <p class="subtitle">Sélectionnez le type d'environnement que vous souhaitez lancer.</p>
-            <div class="card-grid service-catalog">
-                <div class="card service-card" data-service="JupyterLab" data-icon="fa-brands fa-python" data-deployment-type="jupyter">
-                    <i class="fab fa-python service-icon"></i>
-                    <h3>JupyterLab</h3>
-                    <p>Environnement interactif pour data science (Python, R).</p>
-                </div>
-                <div class="card service-card" data-service="VSCode Web" data-icon="fa-solid fa-code" data-deployment-type="vscode">
-                    <i class="fas fa-code service-icon"></i>
-                    <h3>VSCode Web</h3>
-                    <p>IDE complet dans votre navigateur.</p>
-                </div>
-                <div class="card service-card" data-service="Custom" data-icon="fa-solid fa-cube" data-deployment-type="custom">
-                    <i class="fas fa-cube service-icon"></i>
-                    <h3>Personnalisé</h3>
-                    <p>Déploiement d'image Docker personnalisée.</p>
-                </div>
+            <div class="card-grid service-catalog" id="service-catalog">
+                <!-- Rempli dynamiquement depuis /api/v1/k8s/templates -->
             </div>
         </section>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -106,11 +106,7 @@
                     <small>Ce nom sera utilisé pour identifier votre laboratoire</small>
                 </div>
 
-                <div class="form-group">
-                    <label for="namespace"><i class="fas fa-project-diagram"></i> Namespace</label>
-                    <input type="text" id="namespace" name="namespace" value="default">
-                    <small>Namespace Kubernetes où sera déployé votre environnement</small>
-                </div>
+                <!-- Le namespace est désormais géré côté serveur (un par utilisateur) -->
 
                 <div class="form-group">
                     <label for="cpu"><i class="fas fa-microchip"></i> Processeur (vCPU)</label>

--- a/frontend/js/templates.js
+++ b/frontend/js/templates.js
@@ -1,0 +1,177 @@
+// Gestion des templates (CRUD) avec formulaire modale
+
+(function() {
+  const listEl = document.getElementById('templates-list');
+  const addBtn = document.getElementById('add-template-btn');
+  const modal = document.getElementById('template-modal');
+  const closeBtns = modal ? modal.querySelectorAll('.close-template-modal') : [];
+  const form = document.getElementById('template-form');
+  const titleEl = document.getElementById('template-modal-title');
+
+  const idEl = document.getElementById('template-id');
+  const keyEl = document.getElementById('tpl-key');
+  const nameEl = document.getElementById('tpl-name');
+  const descEl = document.getElementById('tpl-description');
+  const iconEl = document.getElementById('tpl-icon');
+  const typeEl = document.getElementById('tpl-type');
+  const imageEl = document.getElementById('tpl-image');
+  const portEl = document.getElementById('tpl-port');
+  const svcTypeEl = document.getElementById('tpl-service-type');
+  const activeEl = document.getElementById('tpl-active');
+
+  if (!listEl || !addBtn) return; // ne pas exécuter si pas sur la page
+
+  function openModal(editing = false, data = null) {
+    titleEl.innerHTML = editing ? '<i class="fas fa-pen"></i> Modifier le template' : '<i class="fas fa-th-large"></i> Nouveau template';
+    form.reset();
+    idEl.value = '';
+    keyEl.disabled = editing; // clé non modifiable en édition
+
+    if (editing && data) {
+      idEl.value = data.id;
+      keyEl.value = data.key;
+      nameEl.value = data.name;
+      descEl.value = data.description || '';
+      iconEl.value = data.icon || '';
+      typeEl.value = data.deployment_type || 'custom';
+      imageEl.value = data.default_image || '';
+      portEl.value = data.default_port || '';
+      svcTypeEl.value = data.default_service_type || 'NodePort';
+      activeEl.checked = !!data.active;
+    }
+
+    modal.classList.add('show');
+  }
+
+  function closeModal() {
+    modal.classList.remove('show');
+  }
+
+  async function api(path, options = {}) {
+    const resp = await fetch(path, { credentials: 'include', ...options });
+    let payload = null;
+    const ct = resp.headers.get('content-type') || '';
+    if (ct.includes('application/json')) payload = await resp.json();
+    if (!resp.ok) {
+      const msg = (payload && (payload.detail || payload.message)) || `HTTP ${resp.status}`;
+      throw new Error(msg);
+    }
+    return payload;
+  }
+
+  async function refreshTemplates() {
+    try {
+      const templates = await api('/api/v1/k8s/templates/all');
+      listEl.innerHTML = `
+        <table class="users-table">
+          <thead>
+            <tr>
+              <th>ID</th><th>Clé</th><th>Nom</th><th>Type</th><th>Image</th><th>Port</th><th>Service</th><th>Actif</th><th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${templates.map(t => `
+              <tr>
+                <td>${t.id}</td>
+                <td>${t.key}</td>
+                <td>${t.name}</td>
+                <td>${t.deployment_type}</td>
+                <td>${t.default_image || '-'}</td>
+                <td>${t.default_port ?? '-'}</td>
+                <td>${t.default_service_type || '-'}</td>
+                <td><span class="status-badge ${t.active ? 'active' : 'inactive'}">${t.active ? 'Actif' : 'Inactif'}</span></td>
+                <td class="action-icons">
+                  <button class="edit-tpl" data-id="${t.id}"><i class="fas fa-edit"></i></button>
+                  <button class="del-tpl" data-id="${t.id}"><i class="fas fa-trash-alt"></i></button>
+                </td>
+              </tr>`).join('')}
+          </tbody>
+        </table>`;
+
+      // Bind actions
+      listEl.querySelectorAll('.edit-tpl').forEach(btn => btn.addEventListener('click', async () => {
+        const id = btn.getAttribute('data-id');
+        const row = btn.closest('tr').children;
+        const current = {
+          id,
+          key: row[1].textContent,
+          name: row[2].textContent,
+          deployment_type: row[3].textContent,
+          default_image: row[4].textContent === '-' ? '' : row[4].textContent,
+          default_port: row[5].textContent === '-' ? '' : parseInt(row[5].textContent),
+          default_service_type: row[6].textContent,
+          active: row[7].querySelector('.status-badge').classList.contains('active')
+        };
+        openModal(true, current);
+      }));
+
+      listEl.querySelectorAll('.del-tpl').forEach(btn => btn.addEventListener('click', async () => {
+        const id = btn.getAttribute('data-id');
+        if (!confirm('Supprimer ce template ?')) return;
+        try {
+          await api(`/api/v1/k8s/templates/${id}`, { method: 'DELETE' });
+          await refreshTemplates();
+        } catch (e) {
+          showInlineError(e.message);
+        }
+      }));
+    } catch (e) {
+      showInlineError(e.message);
+    }
+  }
+
+  function showInlineError(message) {
+    listEl.innerHTML = `<div class="notification error" style="display:flex"><i class="fas fa-exclamation-circle"></i> ${message}</div>`;
+  }
+
+  addBtn.addEventListener('click', () => openModal(false));
+  closeBtns.forEach(btn => btn.addEventListener('click', closeModal));
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const id = idEl.value || null;
+    const body = {
+      key: keyEl.value.trim(),
+      name: nameEl.value.trim(),
+      description: descEl.value.trim() || null,
+      icon: iconEl.value.trim() || null,
+      deployment_type: typeEl.value,
+      default_image: imageEl.value.trim() || null,
+      default_port: portEl.value ? parseInt(portEl.value, 10) : null,
+      default_service_type: svcTypeEl.value,
+      active: activeEl.checked
+    };
+
+    try {
+      if (id) {
+        // Update (clé non modifiable)
+        const payload = { ...body };
+        delete payload.key;
+        await api(`/api/v1/k8s/templates/${id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+      } else {
+        await api('/api/v1/k8s/templates', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        });
+      }
+      closeModal();
+      await refreshTemplates();
+    } catch (e) {
+      // Afficher une erreur utilisateur dans le formulaire
+      const err = document.createElement('div');
+      err.className = 'notification error';
+      err.style.display = 'flex';
+      err.innerHTML = `<i class="fas fa-exclamation-circle"></i> <span>${e.message}</span>`;
+      form.prepend(err);
+      setTimeout(() => err.remove(), 5000);
+    }
+  });
+
+  // Initial load
+  refreshTemplates();
+})();

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -549,22 +549,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             const deploymentName = document.getElementById('deployment-name');
             deploymentName.value = `${serviceName.toLowerCase().replace(/\s+/g, '-')}-${Math.floor(Math.random() * 9000) + 1000}`;
 
-            // Définir un namespace spécifique au type de service au lieu de "default"
-            const namespaceInput = document.getElementById('namespace');
-            switch(deploymentType) {
-                case 'jupyter':
-                    namespaceInput.value = 'labondemand-jupyter';
-                    break;
-                case 'vscode':
-                    namespaceInput.value = 'labondemand-vscode';
-                    break;
-                case 'custom':
-                    namespaceInput.value = 'labondemand-custom';
-                    break;
-                default:
-                    namespaceInput.value = `labondemand-${serviceName.toLowerCase().replace(/\s+/g, '-')}`;
-            }
-
             // Reset form (optional)
             configForm.reset();
 
@@ -582,9 +566,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 document.getElementById('service-type-select').value = defaultServiceType;
             }
 
-            // Rétablir le nom par défaut et le namespace (après reset)
+            // Rétablir le nom par défaut (après reset)
             document.getElementById('deployment-name').value = deploymentName.value;
-            document.getElementById('namespace').value = namespaceInput.value;
 
             showView('config-view');
         });
@@ -596,12 +579,20 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (!resp.ok) throw new Error('Erreur de chargement des templates');
             const data = await resp.json();
             const templates = data.templates || [];
+            const isElevated = authManager.isAdmin() || authManager.isTeacher();
+            // Filtrer pour les étudiants: uniquement jupyter et vscode
+            const filteredTemplates = isElevated
+                ? templates
+                : templates.filter(t => {
+                    const dt = t.deployment_type || (t.id === 'custom' ? 'custom' : t.id);
+                    return dt === 'jupyter' || dt === 'vscode';
+                });
             if (!serviceCatalog) return;
-            if (templates.length === 0) {
+            if (filteredTemplates.length === 0) {
                 serviceCatalog.innerHTML = '<div class="no-items-message">Aucun template disponible</div>';
                 return;
             }
-            serviceCatalog.innerHTML = templates.map(t => {
+            serviceCatalog.innerHTML = filteredTemplates.map(t => {
                 const iconClass = t.icon?.includes('fa-') ? t.icon : 'fa-solid fa-cube';
                 const title = t.name || t.id;
                 const desc = t.description || '';
@@ -626,11 +617,23 @@ document.addEventListener('DOMContentLoaded', async () => {
             console.error(e);
             // Fallback minimal si l'API échoue
             if (serviceCatalog) {
-                serviceCatalog.innerHTML = `
+                const isElevated = authManager.isAdmin() || authManager.isTeacher();
+                // Pour étudiants: proposer uniquement Jupyter et VS Code en fallback
+                serviceCatalog.innerHTML = isElevated ? `
                     <div class="card service-card" data-service="Custom" data-icon="fa-solid fa-cube" data-deployment-type="custom">
                         <i class="fas fa-cube service-icon"></i>
                         <h3>Personnalisé</h3>
                         <p>Déploiement d'image Docker personnalisée.</p>
+                    </div>` : `
+                    <div class="card service-card" data-service="Jupyter Notebook" data-icon="fa-brands fa-python" data-deployment-type="jupyter" data-default-image="tutanka01/k8s:jupyter" data-default-port="8888" data-default-service-type="NodePort">
+                        <i class="fa-brands fa-python service-icon"></i>
+                        <h3>Jupyter Notebook</h3>
+                        <p>Environnement interactif pour Python et data science.</p>
+                    </div>
+                    <div class="card service-card" data-service="VS Code" data-icon="fa-solid fa-code" data-deployment-type="vscode" data-default-image="tutanka01/k8s:vscode" data-default-port="8080" data-default-service-type="NodePort">
+                        <i class="fa-solid fa-code service-icon"></i>
+                        <h3>VS Code</h3>
+                        <p>Éditeur de code accessible via le navigateur.</p>
                     </div>`;
                 document.querySelectorAll('.service-card').forEach(bindServiceCard);
             }
@@ -647,7 +650,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             const serviceIcon = serviceIconInput.value;
             const deploymentType = deploymentTypeInput.value;
             const deploymentName = document.getElementById('deployment-name').value;
-            const namespace = document.getElementById('namespace').value || 'labondemand-' + deploymentType; // Utiliser un namespace spécifique si non défini
             const cpu = document.getElementById('cpu').value;
             const ram = document.getElementById('ram').value;
             
@@ -731,7 +733,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                     name: deploymentName,
                     image: image,
                     replicas: replicas,
-                    namespace: namespace,
                     create_service: createService,
                     service_port: servicePort,
                     service_target_port: serviceTargetPort,
@@ -786,6 +787,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 // Construire les infos du lab à ajouter au dashboard
                 labCounter++;
                 const labId = deploymentName;
+                const effectiveNamespace = data.namespace || 'labondemand-user';
                 
                 // Extraire l'URL d'accès des infos de retour (ou générer une URL factice en attendant de récupérer l'URL réelle)
                 let accessUrl = '';
@@ -809,7 +811,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 if (!accessUrl && nodePort) {
                     // Si on n'a pas d'URL complète mais on a un NodePort, tenter de récupérer les détails
                     try {
-                        const detailsResponse = await fetch(`${API_V1}/k8s/deployments/${namespace}/${deploymentName}/details`);
+                        const detailsResponse = await fetch(`${API_V1}/k8s/deployments/${effectiveNamespace}/${deploymentName}/details`);
                         if (detailsResponse.ok) {
                             const detailsData = await detailsResponse.json();
                             if (detailsData.access_urls && detailsData.access_urls.length > 0) {
@@ -841,7 +843,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     ram: ramValues[ram]?.request || '128Mi',
                     datasets: datasets,
                     link: accessUrl,
-                    namespace: namespace,
+                    namespace: effectiveNamespace,
                     ready: false // Le déploiement commence toujours en état non prêt
                 });
 
@@ -1278,10 +1280,16 @@ document.addEventListener('DOMContentLoaded', async () => {
         const apiConnected = await checkApiStatus();
         
         if (apiConnected) {
-            // Charger les données K8s
-            fetchAndRenderNamespaces();
-            fetchAndRenderPods();
-            fetchAndRenderDeployments();
+            // Charger les données K8s seulement pour admin/teacher
+            const isElevated = authManager.isAdmin() || authManager.isTeacher();
+            if (isElevated) {
+                fetchAndRenderNamespaces();
+                fetchAndRenderPods();
+                fetchAndRenderDeployments();
+            } else {
+                // Étudiants: n'appellent pas les endpoints /namespaces et /pods
+                fetchAndRenderDeployments();
+            }
             
             
             // Récupérer les déploiements existants pour les afficher comme labs actifs

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ Regardez notre vidéo de présentation qui explique les principales fonctionnali
 *   **Configuration des Ressources :** Préréglages de CPU/Mémoire pour adapter les environnements aux besoins spécifiques.
 *   **Accès Simplifié :** Exposition automatique des services via NodePort (configurable pour d'autres types).
 *   **Visualisation :** Tableau de bord pour suivre les laboratoires actifs, les namespaces, pods et déploiements Kubernetes gérés par l'application.
-*   **Templates :** Support pour des templates de déploiement (VS Code, Jupyter, personnalisés) avec des images Docker dédiées.
+*   **Templates :** Templates d'application dynamiques (VS Code, Jupyter, personnalisés) gérés via l'admin; affichés automatiquement aux utilisateurs.
 *   **Validation Intégrée :** Formatage et validation des noms pour la conformité Kubernetes.
 *   **Scalabilité :** Prêt pour une architecture haute disponibilité (voir schéma futur).
 


### PR DESCRIPTION
This pull request introduces major improvements to user namespace isolation for Kubernetes deployments and adds full CRUD support for deployment templates in the database. The changes enforce per-user namespace isolation (especially for students), add baseline resource quotas and limits for namespaces, and migrate deployment template management from static code to database-backed models and endpoints. These updates enhance security, resource management, and flexibility for deployment templates.

**Kubernetes Namespace Isolation & Resource Management:**

* Enforced per-user namespace isolation for deployments: student deployments always use a dedicated namespace (`labondemand-user-<user_id>` by default), ignoring any explicit namespace request; teachers/admins use their own namespace unless an explicit namespace is provided. (`backend/deployment_service.py`, `backend/k8s_utils.py`, `backend/config.py`) [[1]](diffhunk://#diff-e92ee54b0d34748d64f99b5ae82586fb38b47f614f868a8f0659cb9b19f05fb9L209-R220) [[2]](diffhunk://#diff-2c17354395cdef46c0f2af36ddc3b770f3589a14dabbbf99b8b743792b7cfda5R105-R210) [[3]](diffhunk://#diff-651976572b51d1a16ede6a1c4c1be9a1482605ce57ca58fbfca25e4a55c43210R32-R33)
* Added baseline resource quotas and limit ranges to user namespaces on creation, with stricter limits for students. This is applied idempotently and does not block deployment on errors. (`backend/k8s_utils.py`)

**Deployment Template Management:**

* Introduced a new `Template` SQLAlchemy model for deployment templates, with fields for key, name, description, icon, deployment type, default image/port/service type, and active status. (`backend/models.py`)
* Seeded the database with default templates on startup if none exist. (`backend/main.py`)
* Added CRUD API endpoints for templates: list active templates (with role-based filtering), create, update, delete, and admin-only list of all templates. Fallback to code defaults if DB is empty. (`backend/k8s_router.py`)

**General Refactoring & Compatibility:**

* Refactored deployment service and router to ignore explicit namespace parameters for students and consistently use the new namespace isolation logic. (`backend/deployment_service.py`, `backend/k8s_router.py`) [[1]](diffhunk://#diff-e92ee54b0d34748d64f99b5ae82586fb38b47f614f868a8f0659cb9b19f05fb9L191-R192) [[2]](diffhunk://#diff-086feb3b7d5dd25675cf9c5864b6ef7ed3765d121a47c1718313776e7cb5219fL281) [[3]](diffhunk://#diff-086feb3b7d5dd25675cf9c5864b6ef7ed3765d121a47c1718313776e7cb5219fL299-R301)
* Improved code clarity and formatting in deployment creation and service manifest handling. (`backend/deployment_service.py`) [[1]](diffhunk://#diff-e92ee54b0d34748d64f99b5ae82586fb38b47f614f868a8f0659cb9b19f05fb9L233-R249) [[2]](diffhunk://#diff-e92ee54b0d34748d64f99b5ae82586fb38b47f614f868a8f0659cb9b19f05fb9L246-R274) [[3]](diffhunk://#diff-e92ee54b0d34748d64f99b5ae82586fb38b47f614f868a8f0659cb9b19f05fb9L270-R322) [[4]](diffhunk://#diff-e92ee54b0d34748d64f99b5ae82586fb38b47f614f868a8f0659cb9b19f05fb9L294-R346)