### PR TITLE
probleme secrets

### DIFF
--- a/documentation/wordpress.md
+++ b/documentation/wordpress.md
@@ -31,6 +31,10 @@ Cette fonctionnalité permet à chaque utilisateur de déployer une instance Wor
 
 Les secrets sont stockés dans un objet Secret Kubernetes nommé `<name>-secret` dans votre namespace.
 
+Note sur la suppression: lorsque vous supprimez une stack WordPress via l'API de LabOnDemand, le Secret `<name>-secret` et le PVC de la base de données (`<name>-mariadb-pvc`) sont supprimés par défaut afin d'éviter les conflits lors d'une réinstallation (erreur AlreadyExists). Vous pouvez garder ces ressources persistantes en passant le paramètre de requête `delete_persistent=false` à l'endpoint de suppression.
+
+Idempotence: si un Secret `<name>-secret` existe déjà (par exemple après une suppression partielle), le déploiement ne renverra plus d'erreur 409. Le Secret existant sera réutilisé et ses labels seront mis à jour si nécessaire.
+
 ## Ressources et persistance
 
 - MariaDB utilise un `PersistentVolumeClaim` de 1Gi.


### PR DESCRIPTION
This pull request improves the idempotence and resource management for WordPress and MySQL/phpMyAdmin stack deployments and deletions. The main changes ensure that Kubernetes Secrets and Persistent Volume Claims (PVCs) are handled more robustly: existing Secrets are patched rather than replaced, and PVCs/Secrets are deleted by default when removing a stack to prevent redeployment conflicts. Documentation has also been updated to clarify these behaviors.

**Resource creation and deletion improvements:**

* **Idempotent Secret creation:** When creating a Secret for WordPress or MySQL stacks, if the Secret already exists (409 error), the code now patches its labels instead of failing or overwriting, ensuring consistent stack discovery and preventing redeployment errors. [[1]](diffhunk://#diff-e92ee54b0d34748d64f99b5ae82586fb38b47f614f868a8f0659cb9b19f05fb9R942-R958) [[2]](diffhunk://#diff-e92ee54b0d34748d64f99b5ae82586fb38b47f614f868a8f0659cb9b19f05fb9R1191-R1206)
* **Default deletion of persistent resources:** The stack deletion endpoint now removes PVCs and Secrets by default to avoid "AlreadyExists" errors on redeployment. This behavior can be controlled with a new `delete_persistent` parameter. [[1]](diffhunk://#diff-086feb3b7d5dd25675cf9c5864b6ef7ed3765d121a47c1718313776e7cb5219fR895) [[2]](diffhunk://#diff-086feb3b7d5dd25675cf9c5864b6ef7ed3765d121a47c1718313776e7cb5219fL957-R958) [[3]](diffhunk://#diff-086feb3b7d5dd25675cf9c5864b6ef7ed3765d121a47c1718313776e7cb5219fR980-R992) [[4]](diffhunk://#diff-086feb3b7d5dd25675cf9c5864b6ef7ed3765d121a47c1718313776e7cb5219fR1017-R1028)

**Documentation updates:**

* **Clarified deletion and idempotence:** The documentation for WordPress stacks now explains that Secrets and PVCs are deleted by default on stack removal, and describes the new idempotent Secret creation logic. It also notes how to retain persistent resources using the API parameter.