### PR TITLE
correction erreur templates dans l'admin

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -45,6 +45,9 @@ class Settings:
     DEFAULT_NAMESPACES = {
         "jupyter": "labondemand-jupyter",
         "vscode": "labondemand-vscode",
+        "wordpress": "labondemand-wordpress",
+        "mysql": "labondemand-mysql",
+        "lamp": "labondemand-lamp",
         "custom": "labondemand-custom"
     }
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -67,7 +67,8 @@ class TemplateBase(BaseModel):
     name: str = Field(..., min_length=2, max_length=100)
     description: Optional[str] = Field(None, max_length=255)
     icon: Optional[str] = Field(None, max_length=100)
-    deployment_type: str = Field("custom", pattern=r"^(custom|vscode|jupyter|wordpress|mysql)$")
+    # Autoriser les types pris en charge, y compris LAMP
+    deployment_type: str = Field("custom", pattern=r"^(custom|vscode|jupyter|wordpress|mysql|lamp)$")
     default_image: Optional[str] = Field(None, max_length=200)
     default_port: Optional[int] = Field(None, ge=1, le=65535)
     default_service_type: str = Field("NodePort", pattern=r"^(ClusterIP|NodePort|LoadBalancer)$")
@@ -83,7 +84,7 @@ class TemplateUpdate(BaseModel):
     name: Optional[str] = Field(None, min_length=2, max_length=100)
     description: Optional[str] = Field(None, max_length=255)
     icon: Optional[str] = Field(None, max_length=100)
-    deployment_type: Optional[str] = Field(None, pattern=r"^(custom|vscode|jupyter|wordpress|mysql)$")
+    deployment_type: Optional[str] = Field(None, pattern=r"^(custom|vscode|jupyter|wordpress|mysql|lamp)$")
     default_image: Optional[str] = Field(None, max_length=200)
     default_port: Optional[int] = Field(None, ge=1, le=65535)
     default_service_type: Optional[str] = Field(None, pattern=r"^(ClusterIP|NodePort|LoadBalancer)$")

--- a/compose.yaml
+++ b/compose.yaml
@@ -33,6 +33,8 @@ services:
       - "${FRONTEND_PORT:-80}:80"
     volumes:
       - ./frontend:/usr/share/nginx/html
+      # Monter les images partagées utilisées comme favicon/logo
+      - ./Diagrammes/Images:/usr/share/nginx/html/Images:ro
       - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
This pull request adds support for the LAMP deployment type across the backend and configuration files, and improves frontend resource handling by mounting shared images for use as favicon or logo. The main changes are grouped below:

**Backend support for LAMP deployment type:**

* Added `"lamp": "labondemand-lamp"` to the `DEFAULT_NAMESPACES` dictionary in `backend/config.py`, allowing Kubernetes initialization for LAMP environments.
* Updated the `deployment_type` field validation in both `TemplateBase` and `TemplateUpdate` models in `backend/schemas.py` to include `"lamp"` as a valid option. [[1]](diffhunk://#diff-ffffbd4012472eeee22ddd8e6562335fb4edc8d1ba1d83c8db791465f607ff01L70-R71) [[2]](diffhunk://#diff-ffffbd4012472eeee22ddd8e6562335fb4edc8d1ba1d83c8db791465f607ff01L86-R87)

**Frontend resource handling:**

* Modified `compose.yaml` to mount the `./Diagrammes/Images` directory as read-only in the frontend container, enabling shared images to be used as favicon/logo.